### PR TITLE
Fix registering kanalen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,7 @@ Changelog
 0.3.1 (2024-10-27)
 ------------------
 
-* Fixed kanalen not being registered. This regression was introduced in `0.3.0`
-  (through `aa73035c285f7f5157148034a0e87149b6e1bcf0`).
+* Fixed kanalen not being registered. This regression was introduced in `0.3.0`.
 
 0.3.0 (2024-10-24)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+0.3.1 (2024-10-27)
+------------------
+
+* Fixed kanalen not being registered. This regression was introduced in `0.3.0`
+  (through `aa73035c285f7f5157148034a0e87149b6e1bcf0`).
+
 0.3.0 (2024-10-24)
 ------------------
 

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -134,8 +134,6 @@ class Command(BaseCommand):
                     f"Registered kanaal '{kanaal}' with {service.api_root}"
                 )
             except (
-                KanaalRequestException,
-                KanaalCreateException,
-                KanaalExistsException,
+                KanaalException,
             ) as exception:
                 self.stderr.write(f"{str(exception)} . Skipping..")

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -133,7 +133,5 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Registered kanaal '{kanaal}' with {service.api_root}"
                 )
-            except (
-                KanaalException,
-            ) as exception:
+            except (KanaalException,) as exception:
                 self.stderr.write(f"{str(exception)} . Skipping..")

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -121,12 +121,5 @@ class Command(BaseCommand):
                 self.stdout.write(f"Registered kanaal '{kanaal}' with {api_root}")
             except KanaalExists:
                 self.stderr.write(f"Kanaal '{kanaal}' already exists within {api_root}")
-            except KanaalRequestException:
-                self.stderr.write(
-                    f"Request to retrieve existing kanalen for {kanaal} failed. "
-                    "Skipping.."
-                )
-            except KanaalCreateException:
-                self.stderr.write(
-                    f"Request to create kanaal for {kanaal} failed. Skipping.."
-                )
+            except (KanaalRequestException, KanaalCreateException) as exception:
+                self.stderr.write(f"{str(exception)} . Skipping..")

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -70,8 +70,6 @@ def create_kanaal(kanaal: str) -> None:
         f"{protocol}://{domain}{reverse('notifications:kanalen')}#{kanaal}"
     )
 
-    response_data = {}
-
     try:
         response: Response = client.post(
             "kanaal",

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
@@ -22,11 +23,11 @@ class KanaalException(Exception):
     kanaal: str
     data: dict | list
 
-    def __init__(self, kanaal: str, data: dict | list = {}):
+    def __init__(self, kanaal: str, data: Optional[dict | list] = None):
         super().__init__()
 
         self.kanaal = kanaal
-        self.data = data
+        self.data = data or {}
 
 
 class KanaalRequestException(KanaalException):

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
+    "django.contrib.sites",
     "django.contrib.admin",
     "django.contrib.messages",
     "django.contrib.staticfiles",
@@ -64,3 +65,5 @@ TEMPLATES = [
 ]
 
 ROOT_URLCONF = "testapp.urls"
+
+SITE_ID = 1

--- a/tests/test_register_kanalen.py
+++ b/tests/test_register_kanalen.py
@@ -145,11 +145,9 @@ def test_register_kanalen_unknown_url(notifications_config, requests_mock):
 
     call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
 
-    failure_message = (
-        "Request to retrieve existing kanalen for foobar failed. Skipping.."
-    )
+    partial_failure_message = "Unable to retrieve kanaal foobar"
 
-    assert failure_message in stderr.getvalue()
+    assert partial_failure_message in stderr.getvalue()
 
     assert len(requests_mock.request_history) == 1
 
@@ -178,9 +176,9 @@ def test_register_kanalen_incorrect_post(notifications_config, requests_mock):
 
         call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
 
-    failure_message = "Request to create kanaal for foobar failed. Skipping.."
+    partial_failure_message = "Unable to create kanaal foobar"
 
-    assert failure_message in stderr.getvalue()
+    assert partial_failure_message in stderr.getvalue()
 
     assert len(requests_mock.request_history) == 2
 

--- a/tests/test_register_kanalen.py
+++ b/tests/test_register_kanalen.py
@@ -21,9 +21,7 @@ KANAAL_REGISTRY.update(kanalen)
 
 @pytest.mark.django_db
 def test_register_kanalen_success(notifications_config, requests_mock):
-    kanaal_url = (
-        f"{notifications_config.notifications_api_service.api_root}kanaal"
-    )
+    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
     params = urlencode(dict(naam="foobar"))
 
     requests_mock.get(f"{kanaal_url}?{params}", json=[])
@@ -34,11 +32,9 @@ def test_register_kanalen_success(notifications_config, requests_mock):
             "url": "http://example.com",
             "naam": "string",
             "documentatieLink": "http://example.com",
-            "filters": [
-                "string"
-            ],
+            "filters": ["string"],
         },
-        status_code=201
+        status_code=201,
     )
 
     reverse_patch = (
@@ -62,12 +58,8 @@ def test_register_kanalen_success(notifications_config, requests_mock):
 
 
 @pytest.mark.django_db
-def test_register_kanalen_from_registry_success(
-    notifications_config, requests_mock
-):
-    kanaal_url = (
-        f"{notifications_config.notifications_api_service.api_root}kanaal"
-    )
+def test_register_kanalen_from_registry_success(notifications_config, requests_mock):
+    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
 
     url_mapping = {
         kanaal.label: f"{kanaal_url}?{urlencode(dict(naam=kanaal.label))}"
@@ -83,11 +75,9 @@ def test_register_kanalen_from_registry_success(
                 "url": "http://example.com",
                 "naam": kanaal.label,
                 "documentatieLink": "http://example.com",
-                "filters": [
-                    "string"
-                ],
+                "filters": ["string"],
             },
-            status_code=201
+            status_code=201,
         )
 
     reverse_patch = (
@@ -116,15 +106,11 @@ def test_register_kanalen_from_registry_success(
 
 
 @pytest.mark.django_db
-def test_register_kanalen_existing_kanalen(
-    notifications_config, requests_mock
-):
+def test_register_kanalen_existing_kanalen(notifications_config, requests_mock):
     """
     Test that already registered kanalen does not cause issues
     """
-    kanaal_url = (
-        f"{notifications_config.notifications_api_service.api_root}kanaal"
-    )
+    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
     params = urlencode(dict(naam="foobar"))
 
     requests_mock.get(
@@ -136,7 +122,7 @@ def test_register_kanalen_existing_kanalen(
                 "documentatieLink": "http://example.com",
                 "filters": ["string"],
             }
-        ]
+        ],
     )
 
     call_command("register_kanalen", kanalen=["foobar"])
@@ -149,12 +135,8 @@ def test_register_kanalen_existing_kanalen(
 
 
 @pytest.mark.django_db
-def test_register_kanalen_unknown_url(
-    notifications_config, requests_mock
-):
-    kanaal_url = (
-        f"{notifications_config.notifications_api_service.api_root}kanaal"
-    )
+def test_register_kanalen_unknown_url(notifications_config, requests_mock):
+    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
     params = urlencode(dict(naam="foobar"))
 
     requests_mock.get(f"{kanaal_url}?{params}", status_code=404)
@@ -177,21 +159,13 @@ def test_register_kanalen_unknown_url(
 
 
 @pytest.mark.django_db
-def test_register_kanalen_incorrect_post(
-    notifications_config, requests_mock
-):
-    kanaal_url = (
-        f"{notifications_config.notifications_api_service.api_root}kanaal"
-    )
+def test_register_kanalen_incorrect_post(notifications_config, requests_mock):
+    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
     params = urlencode(dict(naam="foobar"))
 
     requests_mock.get(f"{kanaal_url}?{params}", json=[])
 
-    requests_mock.post(
-        kanaal_url,
-        json={"error": "foo"},
-        status_code=400
-    )
+    requests_mock.post(kanaal_url, json={"error": "foo"}, status_code=400)
 
     stderr = StringIO()
 
@@ -204,9 +178,7 @@ def test_register_kanalen_incorrect_post(
 
         call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
 
-    failure_message = (
-        "Request to create kanaal for foobar failed. Skipping.."
-    )
+    failure_message = "Request to create kanaal for foobar failed. Skipping.."
 
     assert failure_message in stderr.getvalue()
 

--- a/tests/test_register_kanalen.py
+++ b/tests/test_register_kanalen.py
@@ -1,0 +1,221 @@
+from io import StringIO
+from unittest.mock import Mock, patch
+from urllib.parse import urlencode
+
+from django.test.testcases import call_command
+
+import pytest
+
+from notifications_api_common.kanalen import KANAAL_REGISTRY, Kanaal
+
+kanalen = set(
+    (
+        Kanaal(label="foobar", main_resource=Mock()),
+        Kanaal(label="boofar", main_resource=Mock()),
+    )
+)
+
+KANAAL_REGISTRY.clear()
+KANAAL_REGISTRY.update(kanalen)
+
+
+@pytest.mark.django_db
+def test_register_kanalen_success(notifications_config, requests_mock):
+    kanaal_url = (
+        f"{notifications_config.notifications_api_service.api_root}kanaal"
+    )
+    params = urlencode(dict(naam="foobar"))
+
+    requests_mock.get(f"{kanaal_url}?{params}", json=[])
+
+    requests_mock.post(
+        kanaal_url,
+        json={
+            "url": "http://example.com",
+            "naam": "string",
+            "documentatieLink": "http://example.com",
+            "filters": [
+                "string"
+            ],
+        },
+        status_code=201
+    )
+
+    reverse_patch = (
+        "notifications_api_common.management.commands.register_kanalen.reverse"
+    )
+
+    with patch(reverse_patch) as mocked_reverse:
+        mocked_reverse.return_value = "/notifications/kanalen"
+
+        call_command("register_kanalen", kanalen=["foobar"])
+
+    assert len(requests_mock.request_history) == 2
+
+    get_request = requests_mock.request_history[0]
+
+    assert get_request._request.url == f"{kanaal_url}?{params}"
+
+    post_request = requests_mock.request_history[1]
+
+    assert post_request._request.url == kanaal_url
+
+
+@pytest.mark.django_db
+def test_register_kanalen_from_registry_success(
+    notifications_config, requests_mock
+):
+    kanaal_url = (
+        f"{notifications_config.notifications_api_service.api_root}kanaal"
+    )
+
+    url_mapping = {
+        kanaal.label: f"{kanaal_url}?{urlencode(dict(naam=kanaal.label))}"
+        for kanaal in kanalen
+    }
+
+    for kanaal in kanalen:
+        requests_mock.get(url_mapping[kanaal.label], json=[])
+
+        requests_mock.post(
+            kanaal_url,
+            json={
+                "url": "http://example.com",
+                "naam": kanaal.label,
+                "documentatieLink": "http://example.com",
+                "filters": [
+                    "string"
+                ],
+            },
+            status_code=201
+        )
+
+    reverse_patch = (
+        "notifications_api_common.management.commands.register_kanalen.reverse"
+    )
+
+    with patch(reverse_patch) as mocked_reverse:
+        mocked_reverse.return_value = "/notifications/kanalen"
+
+        call_command("register_kanalen")
+
+    assert len(requests_mock.request_history) == 4
+
+    # kanalen are sorted by label
+    first_get_request = requests_mock.request_history[0]
+    assert first_get_request._request.url == url_mapping["boofar"]
+
+    first_post_request = requests_mock.request_history[1]
+    assert first_post_request._request.url == kanaal_url
+
+    second_get_request = requests_mock.request_history[2]
+    assert second_get_request._request.url == url_mapping["foobar"]
+
+    second_post_request = requests_mock.request_history[3]
+    assert second_post_request._request.url == kanaal_url
+
+
+@pytest.mark.django_db
+def test_register_kanalen_existing_kanalen(
+    notifications_config, requests_mock
+):
+    """
+    Test that already registered kanalen does not cause issues
+    """
+    kanaal_url = (
+        f"{notifications_config.notifications_api_service.api_root}kanaal"
+    )
+    params = urlencode(dict(naam="foobar"))
+
+    requests_mock.get(
+        f"{kanaal_url}?{params}",
+        json=[
+            {
+                "url": "http://example.com",
+                "naam": "foobar",
+                "documentatieLink": "http://example.com",
+                "filters": ["string"],
+            }
+        ]
+    )
+
+    call_command("register_kanalen", kanalen=["foobar"])
+
+    assert len(requests_mock.request_history) == 1
+
+    request = requests_mock.request_history[0]
+
+    assert request._request.url == f"{kanaal_url}?{params}"
+
+
+@pytest.mark.django_db
+def test_register_kanalen_unknown_url(
+    notifications_config, requests_mock
+):
+    kanaal_url = (
+        f"{notifications_config.notifications_api_service.api_root}kanaal"
+    )
+    params = urlencode(dict(naam="foobar"))
+
+    requests_mock.get(f"{kanaal_url}?{params}", status_code=404)
+
+    stderr = StringIO()
+
+    call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
+
+    failure_message = (
+        "Request to retrieve existing kanalen for foobar failed. Skipping.."
+    )
+
+    assert failure_message in stderr.getvalue()
+
+    assert len(requests_mock.request_history) == 1
+
+    request = requests_mock.request_history[0]
+
+    assert request._request.url == f"{kanaal_url}?{params}"
+
+
+@pytest.mark.django_db
+def test_register_kanalen_incorrect_post(
+    notifications_config, requests_mock
+):
+    kanaal_url = (
+        f"{notifications_config.notifications_api_service.api_root}kanaal"
+    )
+    params = urlencode(dict(naam="foobar"))
+
+    requests_mock.get(f"{kanaal_url}?{params}", json=[])
+
+    requests_mock.post(
+        kanaal_url,
+        json={"error": "foo"},
+        status_code=400
+    )
+
+    stderr = StringIO()
+
+    reverse_patch = (
+        "notifications_api_common.management.commands.register_kanalen.reverse"
+    )
+
+    with patch(reverse_patch) as mocked_reverse:
+        mocked_reverse.return_value = "/notifications/kanalen"
+
+        call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
+
+    failure_message = (
+        "Request to create kanaal for foobar failed. Skipping.."
+    )
+
+    assert failure_message in stderr.getvalue()
+
+    assert len(requests_mock.request_history) == 2
+
+    get_request = requests_mock.request_history[0]
+
+    assert get_request._request.url == f"{kanaal_url}?{params}"
+
+    post_request = requests_mock.request_history[1]
+
+    assert post_request._request.url == kanaal_url

--- a/tests/test_register_webhook.py
+++ b/tests/test_register_webhook.py
@@ -4,7 +4,6 @@ from django.contrib.messages import get_messages
 from django.utils.translation import gettext as _
 
 import pytest
-from requests import Response
 from requests.exceptions import HTTPError, RequestException
 
 from notifications_api_common.admin import register_webhook


### PR DESCRIPTION
[Recently introduced changes](https://github.com/maykinmedia/notifications-api-common/commit/aa73035c285f7f5157148034a0e87149b6e1bcf0#diff-e3b73b1a4bd0f00e04860733f26b3397732c225f6a722d04867e3f5605af7fa1R29) caused kanalen not to be registered as the used `APIClient` now only returns `Response` objects instead of parsed response data, done previously through the `zds_client.client.Client` ([link](https://github.com/maykinmedia/gemma-zds-client/blob/master/zds_client/client.py#L210)).

These changes add the missing parsing that should be done of the responses.