### PR TITLE
:sparkles: [open-zaak/open-notificaties#207] Update existing with register_kanalen

### DIFF
--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -2,12 +2,12 @@ import logging
 from typing import Optional
 
 from django.contrib.sites.models import Site
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.urls import reverse
 
+from ape_pie.client import APIClient
 from requests import Response
 from requests.exceptions import JSONDecodeError, RequestException
-from zgw_consumers.models import Service
 
 from ...kanalen import KANAAL_REGISTRY
 from ...models import NotificationsConfig
@@ -19,59 +19,63 @@ logger = logging.getLogger(__name__)
 class KanaalException(Exception):
     kanaal: str
     data: dict | list
-    service: Service
+    base_url: str
 
-    def __init__(
-        self, kanaal: str, service: Service, data: Optional[dict | list] = None
-    ):
+    def __init__(self, kanaal: str, base_url: str, data: Optional[dict | list] = None):
         super().__init__()
 
         self.kanaal = kanaal
-        self.service = service
+        self.base_url = base_url
         self.data = data or {}
 
 
 class KanaalRequestException(KanaalException):
     def __str__(self) -> str:
         return (
-            f"Unable to retrieve kanaal {self.kanaal} from {self.service}: {self.data}"
+            f"Unable to retrieve kanaal {self.kanaal} from {self.base_url}: {self.data}"
         )
 
 
 class KanaalCreateException(KanaalException):
     def __str__(self) -> str:
-        return f"Unable to create kanaal {self.kanaal} at {self.service}: {self.data}"
+        return f"Unable to create kanaal {self.kanaal} at {self.base_url}: {self.data}"
+
+
+class KanaalUpdateException(KanaalException):
+    def __str__(self) -> str:
+        return f"Unable to update kanaal {self.kanaal} at {self.base_url}: {self.data}"
 
 
 class KanaalExistsException(KanaalException):
     def __str__(self) -> str:
-        return f"Kanaal '{self.kanaal}' already exists within {self.service}"
+        return f"Kanaal '{self.kanaal}' already exists within {self.base_url}"
 
 
-def create_kanaal(kanaal: str, service: Service) -> None:
-    """
-    Create a kanaal, if it doesn't exist yet.
-    """
-    client = NotificationsConfig.get_client()
-
-    assert client
-
-    # look up the exchange in the registry
-    _kanaal = next(k for k in KANAAL_REGISTRY if k.label == kanaal)
-
+def get_kanaal(kanaal: str, client: APIClient) -> dict | None:
     response_data = []
 
     try:
         response: Response = client.get("kanaal", params={"naam": kanaal})
-        kanalen: list[dict] = response.json() or []
+        kanalen: list = response.json()
         response.raise_for_status()
     except (RequestException, JSONDecodeError) as exception:
         raise KanaalRequestException(
-            kanaal=kanaal, service=service, data=response_data
+            kanaal=kanaal, base_url=client.base_url, data=response_data
         ) from exception
+    else:
+        if kanalen:
+            # `Kanaal.naam` is unique in Open Notificaties, so there should only be one
+            if len(kanalen) > 1:
+                logger.error(
+                    "Found more than one Kanaal with naam %s, this should not be possible",
+                    kanaal,
+                )
+            return kanalen[0]
+        return None
 
-    if kanalen:
-        raise KanaalExistsException(kanaal=kanaal, service=service, data=response_data)
+
+def construct_kanaal_request_data(kanaal: str):
+    _kanaal = next(k for k in KANAAL_REGISTRY if k.label == kanaal)
 
     # build up own documentation URL
     domain = Site.objects.get_current().domain
@@ -80,22 +84,48 @@ def create_kanaal(kanaal: str, service: Service) -> None:
         f"{protocol}://{domain}{reverse('notifications:kanalen')}#{kanaal}"
     )
 
-    try:
-        response: Response = client.post(
-            "kanaal",
-            json={
-                "naam": kanaal,
-                "documentatieLink": documentation_url,
-                "filters": list(_kanaal.kenmerken),
-            },
-        )
+    data = {
+        "naam": kanaal,
+        "documentatieLink": documentation_url,
+        "filters": list(_kanaal.kenmerken),
+    }
+    return data
 
-        response_data: dict = response.json() or {}
+
+def create_kanaal(kanaal: str, client) -> None:
+    """
+    Create a kanaal, if it doesn't exist yet.
+    """
+    data = construct_kanaal_request_data(kanaal)
+
+    response_data = {}
+    try:
+        response: Response = client.post("kanaal", json=data)
+
+        response_data: dict = response.json()
         response.raise_for_status()
     except (RequestException, JSONDecodeError) as exception:
         raise KanaalCreateException(
-            kanaal=kanaal, service=service, data=response_data
+            kanaal=kanaal, base_url=client.base_url, data=response_data
         ) from exception
+
+
+def replace_kanaal(kanaal: str, existing_kanaal: dict, client: APIClient) -> None:
+    """
+    Fully update a kanaal, if it doesn't exist yet.
+    """
+    data = construct_kanaal_request_data(kanaal)
+
+    response_data = {}
+    try:
+        response: Response = client.put(existing_kanaal["url"], json=data)
+        response_data: dict = response.json()
+        response.raise_for_status()
+    except (RequestException, JSONDecodeError) as exception:
+        raise KanaalUpdateException(
+            kanaal=kanaal, base_url=client.base_url, data=response_data
+        ) from exception
+    return
 
 
 class Command(BaseCommand):
@@ -115,23 +145,30 @@ class Command(BaseCommand):
         config = NotificationsConfig.get_solo()
 
         if not config.notifications_api_service:
-            self.stderr.write(
+            raise CommandError(
                 "NotificationsConfig does not have a "
                 "`notifications_api_service` configured"
             )
-
-        service = config.notifications_api_service
 
         # use CLI arg or fall back to setting
         kanalen = options["kanalen"] or sorted(
             [kanaal.label for kanaal in KANAAL_REGISTRY]
         )
 
+        client = NotificationsConfig.get_client()
+        assert client
+
         for kanaal in kanalen:
             try:
-                create_kanaal(kanaal, service)
-                self.stdout.write(
-                    f"Registered kanaal '{kanaal}' with {service.api_root}"
-                )
+                if existing_kanaal := get_kanaal(kanaal, client):
+                    replace_kanaal(kanaal, existing_kanaal, client)
+                    self.stdout.write(
+                        f"Updated already existing kanaal '{kanaal}' with {client.base_url}"
+                    )
+                else:
+                    create_kanaal(kanaal, client)
+                    self.stdout.write(
+                        f"Registered kanaal '{kanaal}' with {client.base_url}"
+                    )
             except (KanaalException,) as exception:
                 self.stderr.write(f"{str(exception)} . Skipping..")

--- a/testapp/urls.py
+++ b/testapp/urls.py
@@ -1,6 +1,19 @@
 from django.contrib import admin
 from django.urls import include, path
+from django.views import View
 
 from .api import router
 
-urlpatterns = [path("admin/", admin.site.urls), path("api/", include(router.urls))]
+notifications_patterns = [
+    path("kanalen/", View.as_view(), name="kanalen"),
+]
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include(router.urls)),
+    path(
+        "notifications/",
+        include((notifications_patterns, "notifications"), namespace="notifications"),
+    ),
+]

--- a/tests/test_register_kanalen.py
+++ b/tests/test_register_kanalen.py
@@ -1,12 +1,16 @@
 from io import StringIO
-from unittest.mock import Mock, patch
-from urllib.parse import urlencode
+from unittest.mock import Mock
 
 from django.test.testcases import call_command
 
 import pytest
+from furl import furl
 
 from notifications_api_common.kanalen import KANAAL_REGISTRY, Kanaal
+
+from .conftest import NOTIFICATIONS_API_ROOT
+
+KANALEN_LIST_URL = (furl(NOTIFICATIONS_API_ROOT) / "kanaal").url
 
 
 @pytest.fixture
@@ -14,8 +18,10 @@ def override_kanalen():
 
     kanalen = set(
         (
-            Kanaal(label="foobar", main_resource=Mock()),
-            Kanaal(label="boofar", main_resource=Mock()),
+            Kanaal(
+                label="foobar", main_resource=Mock(), kenmerken=("kenmerk1", "kenmerk2")
+            ),
+            Kanaal(label="boofar", main_resource=Mock(), kenmerken=("kenmerk1",)),
         )
     )
 
@@ -27,13 +33,10 @@ def override_kanalen():
 def test_register_kanalen_success(
     notifications_config, requests_mock, override_kanalen
 ):
-    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
-    params = urlencode(dict(naam="foobar"))
-
-    requests_mock.get(f"{kanaal_url}?{params}", json=[])
-
+    filter_kanaal_url = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
+    requests_mock.get(filter_kanaal_url, json=[])
     requests_mock.post(
-        kanaal_url,
+        KANALEN_LIST_URL,
         json={
             "url": "http://example.com",
             "naam": "string",
@@ -43,53 +46,39 @@ def test_register_kanalen_success(
         status_code=201,
     )
 
-    reverse_patch = (
-        "notifications_api_common.management.commands.register_kanalen.reverse"
-    )
-
-    with patch(reverse_patch) as mocked_reverse:
-        mocked_reverse.return_value = "/notifications/kanalen"
-
-        call_command("register_kanalen", kanalen=["foobar"])
+    call_command("register_kanalen", kanalen=["foobar"])
 
     assert len(requests_mock.request_history) == 2
 
-    get_request = requests_mock.request_history[0]
+    get_request, post_request = requests_mock.request_history
 
-    assert get_request._request.url == f"{kanaal_url}?{params}"
-
-    post_request = requests_mock.request_history[1]
-
-    assert post_request._request.url == kanaal_url
+    assert get_request._request.url == filter_kanaal_url
+    assert post_request._request.url == KANALEN_LIST_URL
 
 
 @pytest.mark.django_db
 def test_register_kanalen_from_registry_success(
     notifications_config, requests_mock, override_kanalen
 ):
-    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
+    filter_kanaal_url1 = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
+    filter_kanaal_url2 = furl(KANALEN_LIST_URL).set({"naam": "boofar"}).url
 
-    url_mapping = {
-        "foobar": f"{kanaal_url}?{urlencode(dict(naam='foobar'))}",
-        "boofar": f"{kanaal_url}?{urlencode(dict(naam='boofar'))}",
-    }
-
-    requests_mock.get(url_mapping["foobar"], json=[])
+    requests_mock.get(filter_kanaal_url1, json=[])
     requests_mock.post(
-        kanaal_url,
+        KANALEN_LIST_URL,
         json={
-            "url": "http://example.com",
+            "url": f"{NOTIFICATIONS_API_ROOT}kanalen/1",
             "naam": "foobar",
             "documentatieLink": "http://example.com",
             "filters": ["string"],
         },
         status_code=201,
     )
-    requests_mock.get(url_mapping["boofar"], json=[])
+    requests_mock.get(filter_kanaal_url2, json=[])
     requests_mock.post(
-        kanaal_url,
+        KANALEN_LIST_URL,
         json={
-            "url": "http://example.com",
+            "url": f"{NOTIFICATIONS_API_ROOT}kanalen/2",
             "naam": "boofar",
             "documentatieLink": "http://example.com",
             "filters": ["string"],
@@ -97,29 +86,19 @@ def test_register_kanalen_from_registry_success(
         status_code=201,
     )
 
-    reverse_patch = (
-        "notifications_api_common.management.commands.register_kanalen.reverse"
-    )
-
-    with patch(reverse_patch) as mocked_reverse:
-        mocked_reverse.return_value = "/notifications/kanalen"
-
-        call_command("register_kanalen")
+    call_command("register_kanalen")
 
     assert len(requests_mock.request_history) == 4
 
     # kanalen are sorted by label
-    first_get_request = requests_mock.request_history[0]
-    assert first_get_request._request.url == url_mapping["boofar"]
+    first_get_request, first_post_request, second_get_request, second_post_request = (
+        requests_mock.request_history
+    )
 
-    first_post_request = requests_mock.request_history[1]
-    assert first_post_request._request.url == kanaal_url
-
-    second_get_request = requests_mock.request_history[2]
-    assert second_get_request._request.url == url_mapping["foobar"]
-
-    second_post_request = requests_mock.request_history[3]
-    assert second_post_request._request.url == kanaal_url
+    assert first_get_request.url == filter_kanaal_url2
+    assert first_post_request.url == KANALEN_LIST_URL
+    assert second_get_request.url == filter_kanaal_url1
+    assert second_post_request.url == KANALEN_LIST_URL
 
 
 @pytest.mark.django_db
@@ -127,40 +106,97 @@ def test_register_kanalen_existing_kanalen(
     notifications_config, requests_mock, override_kanalen
 ):
     """
-    Test that already registered kanalen does not cause issues
+    Test that already registered kanalen are updated
     """
-    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
-    params = urlencode(dict(naam="foobar"))
+    filter_kanaal_url1 = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
+    kanaal_detail_url1 = (furl(KANALEN_LIST_URL) / "1").url
 
     requests_mock.get(
-        f"{kanaal_url}?{params}",
+        filter_kanaal_url1,
         json=[
             {
-                "url": "http://example.com",
+                "url": kanaal_detail_url1,
                 "naam": "foobar",
-                "documentatieLink": "http://example.com",
+                "documentatieLink": "http://old.example.com",
+                "filters": ["string"],
+            }
+        ],
+    )
+    requests_mock.put(
+        kanaal_detail_url1,
+        json=[
+            {
+                "url": kanaal_detail_url1,
+                "naam": "foobar",
+                "documentatieLink": "http://old.example.com",
                 "filters": ["string"],
             }
         ],
     )
 
-    call_command("register_kanalen", kanalen=["foobar"])
+    filter_kanaal_url2 = furl(KANALEN_LIST_URL).set({"naam": "boofar"}).url
+    kanaal_detail_url2 = (furl(KANALEN_LIST_URL) / "2").url
 
-    assert len(requests_mock.request_history) == 1
+    requests_mock.get(
+        filter_kanaal_url2,
+        json=[
+            {
+                "url": kanaal_detail_url2,
+                "naam": "foobar",
+                "documentatieLink": "http://old.example.com",
+                "filters": [],
+            }
+        ],
+    )
+    requests_mock.put(
+        kanaal_detail_url2,
+        json=[
+            {
+                "url": kanaal_detail_url2,
+                "naam": "foobar",
+                "documentatieLink": "http://old.example.com",
+                "filters": [],
+            }
+        ],
+    )
 
-    request = requests_mock.request_history[0]
+    call_command("register_kanalen")
 
-    assert request._request.url == f"{kanaal_url}?{params}"
+    assert len(requests_mock.request_history) == 4
+
+    get_request1, put_request1, get_request2, put_request2 = (
+        requests_mock.request_history
+    )
+    assert get_request1.method == "GET"
+    assert get_request1.url == filter_kanaal_url2
+
+    assert put_request1.method == "PUT"
+    assert put_request1.url == kanaal_detail_url2
+    assert put_request1.json() == {
+        "naam": "boofar",
+        "documentatieLink": "https://example.com/notifications/kanalen/#boofar",
+        "filters": ["kenmerk1"],
+    }
+
+    assert get_request2.method == "GET"
+    assert get_request2.url == filter_kanaal_url1
+
+    assert put_request2.method == "PUT"
+    assert put_request2.url == kanaal_detail_url1
+    assert put_request2.json() == {
+        "naam": "foobar",
+        "documentatieLink": "https://example.com/notifications/kanalen/#foobar",
+        "filters": ["kenmerk1", "kenmerk2"],
+    }
 
 
 @pytest.mark.django_db
 def test_register_kanalen_unknown_url(
     notifications_config, requests_mock, override_kanalen
 ):
-    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
-    params = urlencode(dict(naam="foobar"))
+    filter_kanaal_url = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
 
-    requests_mock.get(f"{kanaal_url}?{params}", status_code=404)
+    requests_mock.get(filter_kanaal_url, status_code=404)
 
     stderr = StringIO()
 
@@ -174,30 +210,21 @@ def test_register_kanalen_unknown_url(
 
     request = requests_mock.request_history[0]
 
-    assert request._request.url == f"{kanaal_url}?{params}"
+    assert request._request.url == filter_kanaal_url
 
 
 @pytest.mark.django_db
 def test_register_kanalen_incorrect_post(
     notifications_config, requests_mock, override_kanalen
 ):
-    kanaal_url = f"{notifications_config.notifications_api_service.api_root}kanaal"
-    params = urlencode(dict(naam="foobar"))
+    filter_kanaal_url = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
 
-    requests_mock.get(f"{kanaal_url}?{params}", json=[])
-
-    requests_mock.post(kanaal_url, json={"error": "foo"}, status_code=400)
+    requests_mock.get(filter_kanaal_url, json=[])
+    requests_mock.post(KANALEN_LIST_URL, json={"error": "foo"}, status_code=400)
 
     stderr = StringIO()
 
-    reverse_patch = (
-        "notifications_api_common.management.commands.register_kanalen.reverse"
-    )
-
-    with patch(reverse_patch) as mocked_reverse:
-        mocked_reverse.return_value = "/notifications/kanalen"
-
-        call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
+    call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
 
     partial_failure_message = "Unable to create kanaal foobar"
 
@@ -205,10 +232,46 @@ def test_register_kanalen_incorrect_post(
 
     assert len(requests_mock.request_history) == 2
 
-    get_request = requests_mock.request_history[0]
+    get_request, post_request = requests_mock.request_history
 
-    assert get_request._request.url == f"{kanaal_url}?{params}"
+    assert get_request._request.url == filter_kanaal_url
+    assert post_request._request.url == KANALEN_LIST_URL
 
-    post_request = requests_mock.request_history[1]
 
-    assert post_request._request.url == kanaal_url
+@pytest.mark.django_db
+def test_register_kanalen_update_fails(
+    notifications_config, requests_mock, override_kanalen
+):
+    filter_kanaal_url = furl(KANALEN_LIST_URL).set({"naam": "foobar"}).url
+    kanaal_detail_url = (furl(KANALEN_LIST_URL) / "1").url
+    requests_mock.get(
+        filter_kanaal_url,
+        json=[
+            {
+                "url": kanaal_detail_url,
+                "naam": "foobar",
+                "documentatieLink": "http://old.example.com",
+                "filters": ["string"],
+            }
+        ],
+    )
+    requests_mock.put(
+        kanaal_detail_url,
+        json={"error": "foo"},
+        status_code=400,
+    )
+
+    stderr = StringIO()
+
+    call_command("register_kanalen", kanalen=["foobar"], stderr=stderr)
+
+    partial_failure_message = "Unable to update kanaal foobar"
+
+    assert partial_failure_message in stderr.getvalue()
+
+    assert len(requests_mock.request_history) == 2
+
+    get_request, put_request = requests_mock.request_history
+
+    assert get_request.url == filter_kanaal_url
+    assert put_request.url == kanaal_detail_url


### PR DESCRIPTION
Closes open-zaak/open-notificaties#207
Required for open-zaak/open-notificaties#156

This does require Open Notificaties to allow PUT to Kanalen (which the spec doesn't allow right now), see https://github.com/open-zaak/open-notificaties/pull/208