### PR TITLE
:bug: Fix incorrect kanaal name anchors on kanalen page

### DIFF
--- a/notifications_api_common/templates/notifications_api_common/kanalen.html
+++ b/notifications_api_common/templates/notifications_api_common/kanalen.html
@@ -24,7 +24,7 @@
     </p>
 
     {% for kanaal in kanalen %}
-      <a name="#{{ kanaal.label }}"></a>
+      <a name="{{ kanaal.label }}"></a>
       <h2>{{ kanaal.label|title }}</h2>
 
       <p><strong>Kanaal</strong></p>


### PR DESCRIPTION
previously this included # in the name, which means that URLs had to add double ## to refer to these sections