### PR TITLE
:sparkles: Remove django.contrib.sites

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -33,7 +33,6 @@ Add the following apps
 .. code-block:: python
 
     ...,
-    "django.contrib.sites",
     "rest_framework",
     "solo",
     "simple_certmanager",

--- a/notifications_api_common/management/commands/register_kanalen.py
+++ b/notifications_api_common/management/commands/register_kanalen.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand, CommandError
 from django.urls import reverse
 
@@ -78,7 +77,7 @@ def construct_kanaal_request_data(kanaal: str):
     _kanaal = next(k for k in KANAAL_REGISTRY if k.label == kanaal)
 
     # build up own documentation URL
-    domain = Site.objects.get_current().domain
+    domain = get_setting("SITE_DOMAIN")
     protocol = "https" if get_setting("IS_HTTPS") else "http"
     documentation_url = (
         f"{protocol}://{domain}{reverse('notifications:kanalen')}#{kanaal}"

--- a/notifications_api_common/settings.py
+++ b/notifications_api_common/settings.py
@@ -12,5 +12,5 @@ NOTIFICATIONS_GUARANTEE_DELIVERY = True
 
 def get_setting(name: str) -> Any:
     this_module = sys.modules[__name__]
-    default = getattr(this_module, name)
+    default = getattr(this_module, name, None)
     return getattr(settings, name, default)

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -28,7 +28,6 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
     "django.contrib.sessions",
-    "django.contrib.sites",
     "django.contrib.admin",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from notifications_api_common.models import NotificationsConfig
 from testapp import urls  # noqa
 
 NOTIFICATIONS_API_ROOT = "http://some-api-root/api/v1/"
+SITE_DOMAIN = "example.com"
 
 
 def dummy_get_response(request):

--- a/tests/test_register_kanalen.py
+++ b/tests/test_register_kanalen.py
@@ -1,6 +1,7 @@
 from io import StringIO
 from unittest.mock import Mock
 
+from django.test import override_settings
 from django.test.testcases import call_command
 
 import pytest
@@ -8,7 +9,7 @@ from furl import furl
 
 from notifications_api_common.kanalen import KANAAL_REGISTRY, Kanaal
 
-from .conftest import NOTIFICATIONS_API_ROOT
+from .conftest import NOTIFICATIONS_API_ROOT, SITE_DOMAIN
 
 KANALEN_LIST_URL = (furl(NOTIFICATIONS_API_ROOT) / "kanaal").url
 
@@ -30,6 +31,7 @@ def override_kanalen():
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_success(
     notifications_config, requests_mock, override_kanalen
 ):
@@ -54,9 +56,15 @@ def test_register_kanalen_success(
 
     assert get_request._request.url == filter_kanaal_url
     assert post_request._request.url == KANALEN_LIST_URL
+    assert post_request.json() == {
+        "naam": "foobar",
+        "documentatieLink": "https://example.com/notifications/kanalen/#foobar",
+        "filters": ["kenmerk1", "kenmerk2"],
+    }
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_from_registry_success(
     notifications_config, requests_mock, override_kanalen
 ):
@@ -102,6 +110,7 @@ def test_register_kanalen_from_registry_success(
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_existing_kanalen(
     notifications_config, requests_mock, override_kanalen
 ):
@@ -191,6 +200,7 @@ def test_register_kanalen_existing_kanalen(
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_unknown_url(
     notifications_config, requests_mock, override_kanalen
 ):
@@ -214,6 +224,7 @@ def test_register_kanalen_unknown_url(
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_incorrect_post(
     notifications_config, requests_mock, override_kanalen
 ):
@@ -239,6 +250,7 @@ def test_register_kanalen_incorrect_post(
 
 
 @pytest.mark.django_db
+@override_settings(SITE_DOMAIN=SITE_DOMAIN)
 def test_register_kanalen_update_fails(
     notifications_config, requests_mock, override_kanalen
 ):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+from django.test import override_settings
+
+from notifications_api_common.settings import get_setting
+
+
+@override_settings(SITE_DOMAIN="example.com")
+def test_get_settings():
+    assert get_setting("SITE_DOMAIN") == "example.com"
+
+
+def test_get_settings_null_value():
+    assert get_setting("SITE_DOMAIN") is None


### PR DESCRIPTION
Partially fixed https://github.com/maykinmedia/open-api-framework/issues/59
Removed `django.contrib.sites` in `register_kanalen.py`