### PR TITLE
:bug: [#37] Fix documentation: Mark notifications_api_service_identifier as required

### DIFF
--- a/notifications_api_common/contrib/setup_configuration/models.py
+++ b/notifications_api_common/contrib/setup_configuration/models.py
@@ -6,7 +6,10 @@ from notifications_api_common.models import NotificationsConfig, Subscription
 
 class NotificationConfigurationModel(ConfigurationModel):
     notifications_api_service_identifier: str = DjangoModelRef(
-        NotificationsConfig, "notifications_api_service", examples=["notificaties-api"]
+        NotificationsConfig,
+        "notifications_api_service",
+        examples=["notificaties-api"],
+        default=...,
     )
 
     class Meta:


### PR DESCRIPTION
Closes #37 