### PR TITLE
✨ Add TIME_LEEWAY setting

### DIFF
--- a/notifications_api_common/settings.py
+++ b/notifications_api_common/settings.py
@@ -11,6 +11,8 @@ NOTIFICATIONS_GUARANTEE_DELIVERY = True
 
 NOTIFICATIONS_API_GET_DOMAIN = "notifications_api_common.utils.get_site_domain"
 
+TIME_LEEWAY = 0
+
 
 def get_setting(name: str) -> Any:
     this_module = sys.modules[__name__]

--- a/notifications_api_common/validators.py
+++ b/notifications_api_common/validators.py
@@ -1,9 +1,12 @@
 import logging
+from datetime import timedelta
 
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.deconstruct import deconstructible
 from django.utils.translation import gettext_lazy as _
+
+from .settings import get_setting
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +17,8 @@ class UntilNowValidator:
     Validate a datetime to not be in the future.
 
     This means that `now` is included.
+
+    Some leeway can be added with the TIME_LEEWAY setting.
     """
 
     message = _("Ensure this value is not in the future.")
@@ -21,7 +26,7 @@ class UntilNowValidator:
 
     @property
     def limit_value(self):
-        return timezone.now()
+        return timezone.now() + timedelta(seconds=get_setting("TIME_LEEWAY"))
 
     def __call__(self, value):
         if value > self.limit_value:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from django.core.exceptions import ValidationError
+
+import pytest
+from freezegun import freeze_time
+
+from notifications_api_common.validators import UntilNowValidator
+
+
+@freeze_time("2021-08-23T14:20:00")
+def test_invalid_date():
+    validator = UntilNowValidator()
+    with pytest.raises(ValidationError) as error:
+        validator(datetime(2021, 8, 23, 14, 20, 4))
+    assert "Ensure this value is not in the future." in str(error.value)
+
+
+@freeze_time("2021-08-23T14:20:00")
+def test_invalid_date_with_leeway(settings):
+    settings.TIME_LEEWAY = 5
+    validator = UntilNowValidator()
+    validator(datetime(2021, 8, 23, 14, 20, 4))


### PR DESCRIPTION
https://github.com/open-zaak/open-zaak/issues/635

Adds TIME_LEEWAY setting for UntilNowValidator.

This Validator also exists in `commonground-api-common` but then it will only be imported for this validator.