### PR TITLE
:construction_worker: Use trusted publishing to publish to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,5 @@ jobs:
           python -m build
 
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        # pinned to sha for v1.13.0
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e


### PR DESCRIPTION
This is overall a more secure method to upload, because we no longer rely on static, long lived tokens that are usable until revoked